### PR TITLE
Fix being able to import a class name if there is a trailing comma

### DIFF
--- a/lib/Util/WordAtOffset.php
+++ b/lib/Util/WordAtOffset.php
@@ -8,7 +8,7 @@ use RuntimeException;
 final class WordAtOffset
 {
     const SPLIT_WORD = '\s|;|\\\|%|\(|\)|\[|\]|:|\r|\r\n|\n';
-    const SPLIT_QUALIFIED_PHP_NAME = '\?|\s|;|%|\(|\)|\[|\]|:|\r|\r\n|\n';
+    const SPLIT_QUALIFIED_PHP_NAME = '\?|\s|;|,|%|\(|\)|\[|\]|:|\r|\r\n|\n';
 
     /**
      * @var string

--- a/tests/Unit/Util/WordAtOffsetTest.php
+++ b/tests/Unit/Util/WordAtOffsetTest.php
@@ -71,5 +71,10 @@ class WordAtOffsetTest extends TestCase
             'Request',
             WordAtOffset::SPLIT_QUALIFIED_PHP_NAME
         ];
+        yield 'trailing comma' => [
+            "Reque<>st,",
+            'Request',
+            WordAtOffset::SPLIT_QUALIFIED_PHP_NAME
+        ];
     }
 }


### PR DESCRIPTION
Fixes https://github.com/phpactor/phpactor/issues/851