### PR TITLE
Fix handling of the pipe as type separator

### DIFF
--- a/lib/Util/WordAtOffset.php
+++ b/lib/Util/WordAtOffset.php
@@ -8,7 +8,7 @@ use RuntimeException;
 final class WordAtOffset
 {
     const SPLIT_WORD = '\s|;|\\\|%|\(|\)|\[|\]|:|\r|\r\n|\n';
-    const SPLIT_QUALIFIED_PHP_NAME = '\?|\s|;|,|%|\(|\)|\[|\]|:|\r|\r\n|\n';
+    const SPLIT_QUALIFIED_PHP_NAME = '\?|\s|;|,|\||%|\(|\)|\[|\]|:|\r|\r\n|\n';
 
     /**
      * @var string

--- a/tests/Unit/Util/WordAtOffsetTest.php
+++ b/tests/Unit/Util/WordAtOffsetTest.php
@@ -76,5 +76,10 @@ class WordAtOffsetTest extends TestCase
             'Request',
             WordAtOffset::SPLIT_QUALIFIED_PHP_NAME
         ];
+        yield 'pipe type separator' => [
+            "Reque<>st|null,",
+            'Request',
+            WordAtOffset::SPLIT_QUALIFIED_PHP_NAME
+        ];
     }
 }


### PR DESCRIPTION
All in the title: `Type|null` was handled as a all, now the `|`is consider as a separator