### PR TITLE
Allow to import class in annotations (split with @)

### DIFF
--- a/lib/Util/WordAtOffset.php
+++ b/lib/Util/WordAtOffset.php
@@ -8,7 +8,7 @@ use RuntimeException;
 final class WordAtOffset
 {
     const SPLIT_WORD = '\s|;|\\\|%|\(|\)|\[|\]|:|\r|\r\n|\n';
-    const SPLIT_QUALIFIED_PHP_NAME = '\?|\s|;|,|\||%|\(|\)|\[|\]|:|\r|\r\n|\n';
+    const SPLIT_QUALIFIED_PHP_NAME = '\?|\s|;|,|@|\||%|\(|\)|\[|\]|:|\r|\r\n|\n';
 
     /**
      * @var string

--- a/tests/Unit/Util/WordAtOffsetTest.php
+++ b/tests/Unit/Util/WordAtOffsetTest.php
@@ -81,5 +81,10 @@ class WordAtOffsetTest extends TestCase
             'Request',
             WordAtOffset::SPLIT_QUALIFIED_PHP_NAME
         ];
+        yield 'annotations' => [
+            "@Reque<>st",
+            'Request',
+            WordAtOffset::SPLIT_QUALIFIED_PHP_NAME
+        ];
     }
 }


### PR DESCRIPTION
Right now importing an annotation like this does not work:

```php
    /**
     * @NotBla<>nk
     */
    public $username;
```

`No classes found with name "@NotBlank"`.                                                                                                                                                                                       