### PR TITLE
Fix embedded annotations, with = sign

### DIFF
--- a/lib/Util/WordAtOffset.php
+++ b/lib/Util/WordAtOffset.php
@@ -8,7 +8,7 @@ use RuntimeException;
 final class WordAtOffset
 {
     const SPLIT_WORD = '\s|;|\\\|%|\(|\)|\[|\]|:|\r|\r\n|\n';
-    const SPLIT_QUALIFIED_PHP_NAME = '\?|\s|;|,|@|\||%|\(|\)|\[|\]|:|\r|\r\n|\n';
+    const SPLIT_QUALIFIED_PHP_NAME = '\?|\s|;|,|@|=|\||%|\(|\)|\[|\]|:|\r|\r\n|\n';
 
     /**
      * @var string

--- a/tests/Unit/Util/WordAtOffsetTest.php
+++ b/tests/Unit/Util/WordAtOffsetTest.php
@@ -86,5 +86,10 @@ class WordAtOffsetTest extends TestCase
             'Request',
             WordAtOffset::SPLIT_QUALIFIED_PHP_NAME
         ];
+        yield 'subannotations (removing equal)' => [
+             "* input=Re<>quest::class",
+            'Request',
+            WordAtOffset::SPLIT_QUALIFIED_PHP_NAME
+        ];
     }
 }


### PR DESCRIPTION
Fixes this kind of cases:

```
/**
 * @ApiResource(
 *   input=Input::class,
 *   output=Output::class
 * )
 */
```