### PR TITLE
Can sort locations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,8 @@
     "name": "phpactor/text-document",
     "description": "Collection of value objects for representing and referencing text documents",
     "license": "MIT",
+    "prefer-stable": true,
+    "minimum-stability": "dev",
     "authors": [
         {
             "name": "Daniel Leech",

--- a/lib/Locations.php
+++ b/lib/Locations.php
@@ -32,7 +32,7 @@ final class Locations implements IteratorAggregate, Countable
      */
     public static function bySorting(iterable $locations, ?callable $sortStrategy = null): self
     {
-        return (new self($locations))->sort($sortStrategy);
+        return (new self($locations))->sorted($sortStrategy);
     }
 
     /**
@@ -76,7 +76,7 @@ final class Locations implements IteratorAggregate, Countable
         return reset($this->locations);
     }
 
-    public function sort(?callable $sortStrategy = null): self
+    public function sorted(?callable $sortStrategy = null): self
     {
         usort($this->locations, $sortStrategy ?: self::defaultSortStrategy());
 

--- a/lib/Locations.php
+++ b/lib/Locations.php
@@ -70,7 +70,9 @@ final class Locations implements IteratorAggregate, Countable
 
     public function sorted(): self
     {
-        usort($this->locations, function (Location $first, Location $second) {
+        $sortedLocations = $this->locations;
+
+        usort($sortedLocations, function (Location $first, Location $second) {
             $order = strcmp((string) $first->uri(), (string) $second->uri());
             if (0 !== $order) {
                 return $order;
@@ -79,6 +81,6 @@ final class Locations implements IteratorAggregate, Countable
             return $first->offset()->toInt() - $second->offset()->toInt();
         });
 
-        return $this;
+        return new self($sortedLocations);
     }
 }

--- a/lib/Locations.php
+++ b/lib/Locations.php
@@ -30,9 +30,9 @@ final class Locations implements IteratorAggregate, Countable
     /**
      * @param iterable<Location> $locations
      */
-    public static function bySorting(iterable $locations, ?callable $sortStrategy = null): self
+    public static function bySorting(iterable $locations): self
     {
-        return (new self($locations))->sorted($sortStrategy);
+        return (new self($locations))->sorted();
     }
 
     /**
@@ -76,22 +76,17 @@ final class Locations implements IteratorAggregate, Countable
         return reset($this->locations);
     }
 
-    public function sorted(?callable $sortStrategy = null): self
+    public function sorted(): self
     {
-        usort($this->locations, $sortStrategy ?: self::defaultSortStrategy());
-
-        return $this;
-    }
-
-    private static function defaultSortStrategy(): callable
-    {
-        return function (Location $first, Location $second) {
+        usort($this->locations, function (Location $first, Location $second) {
             $order = strcmp((string) $first->uri(), (string) $second->uri());
             if (0 !== $order) {
                 return $order;
             }
 
             return $first->offset()->toInt() - $second->offset()->toInt();
-        };
+        });
+
+        return $this;
     }
 }

--- a/lib/Locations.php
+++ b/lib/Locations.php
@@ -10,7 +10,7 @@ use RuntimeException;
 /**
  * @implements IteratorAggregate<Location>
  */
-class Locations implements IteratorAggregate, Countable
+final class Locations implements IteratorAggregate, Countable
 {
     /**
      * @var Location[]
@@ -18,13 +18,21 @@ class Locations implements IteratorAggregate, Countable
     private $locations = [];
 
     /**
-     * @param Location[] $locations
+     * @param iterable<Location> $locations
      */
-    public function __construct(array $locations)
+    public function __construct(iterable $locations)
     {
         foreach ($locations as $location) {
             $this->add($location);
         }
+    }
+
+    /**
+     * @param iterable<Location> $locations
+     */
+    public static function bySorting(iterable $locations, ?callable $sortStrategy = null): self
+    {
+        return (new self($locations))->sort($sortStrategy);
     }
 
     /**
@@ -45,9 +53,11 @@ class Locations implements IteratorAggregate, Countable
         return new self($newLocations);
     }
 
-    private function add(Location $location): void
+    private function add(Location $location): self
     {
         $this->locations[] = $location;
+
+        return $this;
     }
 
     public function count(): int
@@ -64,5 +74,24 @@ class Locations implements IteratorAggregate, Countable
         }
 
         return reset($this->locations);
+    }
+
+    public function sort(?callable $sortStrategy = null): self
+    {
+        usort($this->locations, $sortStrategy ?: self::defaultSortStrategy());
+
+        return $this;
+    }
+
+    private static function defaultSortStrategy(): callable
+    {
+        return function (Location $first, Location $second) {
+            $order = strcmp((string) $first->uri(), (string) $second->uri());
+            if (0 !== $order) {
+                return $order;
+            }
+
+            return $first->offset()->toInt() - $second->offset()->toInt();
+        };
     }
 }

--- a/lib/Locations.php
+++ b/lib/Locations.php
@@ -28,14 +28,6 @@ final class Locations implements IteratorAggregate, Countable
     }
 
     /**
-     * @param iterable<Location> $locations
-     */
-    public static function bySorting(iterable $locations): self
-    {
-        return (new self($locations))->sorted();
-    }
-
-    /**
      * @return ArrayIterator<int,Location>
      */
     public function getIterator(): ArrayIterator

--- a/tests/Unit/LocationsTest.php
+++ b/tests/Unit/LocationsTest.php
@@ -50,22 +50,6 @@ class LocationsTest extends TestCase
         ]), $locations);
     }
 
-    public function testCreateSortedLocations(): void
-    {
-        $locationList = [
-            Location::fromPathAndOffset('/path/to.php', 12),
-            Location::fromPathAndOffset('/path/from.php', 13),
-            Location::fromPathAndOffset('/path/to.php', 15),
-        ];
-        $locations = Locations::bySorting($locationList);
-
-        $this->assertEquals([
-            $locationList[1],
-            $locationList[0],
-            $locationList[2],
-        ], iterator_to_array($locations));
-    }
-
     /**
      * @dataProvider provideUnsortedLocations
      *

--- a/tests/Unit/LocationsTest.php
+++ b/tests/Unit/LocationsTest.php
@@ -78,7 +78,7 @@ class LocationsTest extends TestCase
     ): void {
         $locations = new Locations($unsortedLocations);
 
-        $this->assertEquals($sortedLocations, iterator_to_array($locations->sort()));
+        $this->assertEquals($sortedLocations, iterator_to_array($locations->sorted()));
     }
 
     /**

--- a/tests/Unit/LocationsTest.php
+++ b/tests/Unit/LocationsTest.php
@@ -9,7 +9,7 @@ use RuntimeException;
 
 class LocationsTest extends TestCase
 {
-    public function testContainsLocations()
+    public function testContainsLocations(): void
     {
         $locations = new Locations([
             Location::fromPathAndOffset('/path/to.php', 12),
@@ -18,7 +18,7 @@ class LocationsTest extends TestCase
         $this->assertCount(2, $locations);
     }
 
-    public function testIsCountable()
+    public function testIsCountable(): void
     {
         $locations = new Locations([
             Location::fromPathAndOffset('/path/to.php', 12),
@@ -27,7 +27,7 @@ class LocationsTest extends TestCase
         $this->assertEquals(2, $locations->count());
     }
 
-    public function testExceptionIfFirstNotAvailable()
+    public function testExceptionIfFirstNotAvailable(): void
     {
         $this->expectException(RuntimeException::class);
         $locations = new Locations([
@@ -35,7 +35,7 @@ class LocationsTest extends TestCase
         $locations->first();
     }
 
-    public function testAppendLocations()
+    public function testAppendLocations(): void
     {
         $locations = new Locations([
             Location::fromPathAndOffset('/path/to.php', 12),
@@ -48,5 +48,52 @@ class LocationsTest extends TestCase
             Location::fromPathAndOffset('/path/to.php', 12),
             Location::fromPathAndOffset('/path/to.php', 13)
         ]), $locations);
+    }
+
+    public function testCreateSortedLocations(): void
+    {
+        $locationList = [
+            Location::fromPathAndOffset('/path/to.php', 12),
+            Location::fromPathAndOffset('/path/from.php', 13),
+            Location::fromPathAndOffset('/path/to.php', 15),
+        ];
+        $locations = Locations::bySorting($locationList);
+
+        $this->assertEquals([
+            $locationList[1],
+            $locationList[0],
+            $locationList[2],
+        ], iterator_to_array($locations));
+    }
+
+    /**
+     * @dataProvider provideUnsortedLocations
+     *
+     * @param Location[] $unsortedLocations
+     * @param Location[] $sortedLocations
+     */
+    public function testSortLocations(
+        array $unsortedLocations,
+        array $sortedLocations
+    ): void {
+        $locations = new Locations($unsortedLocations);
+
+        $this->assertEquals($sortedLocations, iterator_to_array($locations->sort()));
+    }
+
+    /**
+     * @return iterable<array>
+     */
+    public function provideUnsortedLocations(): iterable
+    {
+        yield '2 files and 3 references' => [[
+            Location::fromPathAndOffset('/path/to.php', 15),
+            Location::fromPathAndOffset('/path/to.php', 12),
+            Location::fromPathAndOffset('/path/from.php', 13),
+        ], [
+            Location::fromPathAndOffset('/path/from.php', 13),
+            Location::fromPathAndOffset('/path/to.php', 12),
+            Location::fromPathAndOffset('/path/to.php', 15),
+        ]];
     }
 }

--- a/tests/Unit/LocationsTest.php
+++ b/tests/Unit/LocationsTest.php
@@ -53,16 +53,18 @@ class LocationsTest extends TestCase
     /**
      * @dataProvider provideUnsortedLocations
      *
-     * @param Location[] $unsortedLocations
-     * @param Location[] $sortedLocations
+     * @param Location[] $unsortedLocationsArray
+     * @param Location[] $sortedLocationsArray
      */
     public function testSortLocations(
-        array $unsortedLocations,
-        array $sortedLocations
+        array $unsortedLocationsArray,
+        array $sortedLocationsArray
     ): void {
-        $locations = new Locations($unsortedLocations);
+        $locations = new Locations($unsortedLocationsArray);
+        $sortedLocations = $locations->sorted();
 
-        $this->assertEquals($sortedLocations, iterator_to_array($locations->sorted()));
+        $this->assertNotSame($locations, $sortedLocations);
+        $this->assertEquals($sortedLocationsArray, iterator_to_array($sortedLocations));
     }
 
     /**


### PR DESCRIPTION
The idea was to be able to sort locations directly from the list object.
From there I also replaced `array` by `iterable` in the type hints so the code is more compliant.
And I made the class final to avoid any surprises because of the `new self()`.
This last point is a matter of taste, personally I don't like surprises and I don't see the point of extending it anyway, but if you prefer I can remove it quit easily.

If validated, the changes will be used to sort the result of the "find references" feature.